### PR TITLE
Add basic Sign In with Apple

### DIFF
--- a/AppleSignInTest/AppleSignInTest/ViewController.swift
+++ b/AppleSignInTest/AppleSignInTest/ViewController.swift
@@ -6,14 +6,60 @@
 //
 
 import UIKit
+import AuthenticationServices
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+
+    private var authorizationButton: ASAuthorizationAppleIDButton?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        if #available(iOS 13.0, *) {
+            let button = ASAuthorizationAppleIDButton()
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.addTarget(self, action: #selector(handleAppleIDButtonPress), for: .touchUpInside)
+            view.addSubview(button)
+            NSLayoutConstraint.activate([
+                button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            ])
+            authorizationButton = button
+        }
     }
 
+    @objc private func handleAppleIDButtonPress() {
+        if #available(iOS 13.0, *) {
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+
+    // MARK: - ASAuthorizationControllerDelegate
+
+    @available(iOS 13.0, *)
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        // Handle successful authorization
+        print("Authorized: \(authorization)")
+    }
+
+    @available(iOS 13.0, *)
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // Handle error
+        print("Authorization error: \(error.localizedDescription)")
+    }
+
+    // MARK: - ASAuthorizationControllerPresentationContextProviding
+
+    @available(iOS 13.0, *)
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return view.window ?? ASPresentationAnchor()
+    }
 
 }
 


### PR DESCRIPTION
## Summary
- add AuthenticationServices
- render an Apple Sign In button centered on screen
- handle sign in result using `ASAuthorizationController`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685d553ecac88324871fd9a13b78f832